### PR TITLE
Update website to latest content

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,4 +143,4 @@ DEPENDENCIES
   wdm (>= 0.1.0)
 
 BUNDLED WITH
-   1.11.0
+   1.15.1

--- a/README.md
+++ b/README.md
@@ -2,10 +2,9 @@
 
 ## Installing Jekyll
 
-1. Install Ruby 2.1 ([Linux](https://www.ruby-lang.org/en/documentation/installation/), [Mac](https://gorails.com/setup/osx/10.10-yosemite), [Windows](http://rubyinstaller.org/))
+1. Install Ruby 2.2 ([Linux](https://www.ruby-lang.org/en/documentation/installation/), [Mac](https://gorails.com/setup/osx/10.10-yosemite), [Windows](http://rubyinstaller.org/))
 2. If you are on Windows, install [DevKit](http://rubyinstaller.org/add-ons/devkit/)
-3. `gem install jekyll`
-4. `gem install bundler`
+3. `gem install bundler`
 
 ## Initializing the project
 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -8,7 +8,7 @@
         <span class="icon-bar"></span>
         </button>
         <a class="navbar-brand" href="/">
-            <div class="navbar-brand grow">        
+            <div class="navbar-brand grow">
                 <img src="/img/nunit.svg" />
             </div>
         </a>
@@ -17,7 +17,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="https://github.com/nunit/nunit/wiki" target="_blank"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://github.com/nunit/docs/wiki/NUnit-Documentation" target="_blank"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://github.com/nunit/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -17,7 +17,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="https://github.com/nunit/docs/wiki/NUnit-Documentation" target="_blank"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://github.com/nunit/docs/wiki" target="_blank"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://github.com/nunit/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -8,10 +8,11 @@ layout: default
             <header>
                 <h1 itemprop="name headline">{{ page.title }}</h1>
                 <p>
-                    <time datetime="{{ page.date | date_to_xmlschema }}" itemprop="datePublished">{{ page.date | date: "%b %-d, %Y" }}</time>
+                    <em><i class="fa fa-calendar" aria-hidden="true"></i> <time datetime="{{ page.date | date_to_xmlschema }}" itemprop="datePublished">{{ page.date | date: "%b %-d, %Y" }}</time></em>
                     {% if page.author %}
                      • <span itemprop="author" itemscope itemtype="http://schema.org/Person"><span itemprop="name">{{ page.author }}</span></span>
                     {% endif %}</p>
+                    <hr />
             </header>
 
             <div itemprop="articleBody">

--- a/_posts/2015-12-14-hello_world.md
+++ b/_posts/2015-12-14-hello_world.md
@@ -1,9 +1,0 @@
----
-layout: post
-title:  "Hello World!"
-date:   2015-12-14 18:18:53 -0500
-categories: news update
----
-You’ll find this post in your `_posts` directory. Go ahead and edit it and re-build the site to see your changes. You can rebuild the site in many different ways, but the most common way is to run `jekyll serve`, which launches a web server and auto-regenerates your site when a file is updated.
-
-To add new posts, simply add a file in the `_posts` directory that follows the convention `YYYY-MM-DD-name-of-post.ext` and includes the necessary front matter. Take a look at the source for this post to get an idea about how it works.

--- a/_posts/2017-03-16-nunit-xamarin.md
+++ b/_posts/2017-03-16-nunit-xamarin.md
@@ -1,0 +1,11 @@
+---
+layout: post
+title:  "NUnit Xamarin Runners 3.6.1 Released"
+date:   2017-03-16 12:00:00 -0000
+categories: news update nunit
+---
+An update to the NUnit Xamarin runners has been released. This update includes a number of new features including XML output, results over TCP, and improvements for integration with CI systems.
+
+Install the runners from [NuGet](https://www.nuget.org/packages/nunit.xamarin/) or by searching for the package nunit.xamarin.
+
+For more information, see the [GitHub](https://github.com/nunit/nunit.xamarin) page.

--- a/_posts/2017-04-04-nunit-templates-13.md
+++ b/_posts/2017-04-04-nunit-templates-13.md
@@ -1,0 +1,11 @@
+---
+layout: post
+title:  "NUnit Visual Studio Templates 1.3 Released"
+date:   2017-04-04 12:00:00 -0000
+categories: news update nunit
+---
+We have released an update to the NUnit Visual Studio Templates, to integrate with Visual Studio 2017.
+
+The release also includes various bug fixes, and upgrades the templates to the latest versions of the framework and nunit.xamarin.
+
+Download from the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=NUnitDevelopers.NUnitTemplatesforVisualStudio).

--- a/_posts/2017-05-29-nunit-37.md
+++ b/_posts/2017-05-29-nunit-37.md
@@ -1,0 +1,13 @@
+---
+layout: post
+title:  "NUnit 3.7 Released"
+date:   2017-05-29 12:00:00 -0000
+categories: news update nunit
+---
+This release of NUnit expands on parallel test execution allowing test methods to be run in parallel.
+
+NUnit 3.7 also drops the Portable build of the framework and replaces it with a .NET Standard 1.3 version to compliment the .NET Standard 1.6 version.
+
+The AssertionHelper class has been deprecated. If you are using it, we recommend that you migrate your asserts.
+
+You may download NUnit 3.7 from [Github](https://github.com/nunit/nunit/releases). See the [release notes](https://github.com/nunit/docs/wiki/Release-Notes) for more information.

--- a/contact.md
+++ b/contact.md
@@ -5,17 +5,16 @@ icon: fa-envelope-o
 permalink: /contact/
 ---
 
-The [nunit-discuss](http://groups.google.com/group/nunit-discuss) mailing list is the best place to start. It is monitored regularly 
+The [nunit-discuss](http://groups.google.com/group/nunit-discuss) mailing list is the best place to start. It is monitored regularly
 by the NUnit developers and other experienced users. Describe your problem clearly and be sure to indicate the version of NUnit you are using.
 
-**Note:** The list to reject posts from non-subscribers. Subscribe to the list first, using the same email address from which you plan to post.
+**Note:** The list moderates all posts from non-subscribers. To prevent moderation, subscribe to the list first, using the same email address from which you plan to post.
 
 ## <i class="fa fa-bug"></i> Report a bug or Request a new feature
 
-Please note, **Many 3rd party test runners do not support NUnit 3 yet.** Before you report a bug against NUnit, run your tests in the console first.
- 
-Bugs, enhancements and feature requests should be entered as issues in the appropriate GitHub repository listed below. Before submitting bugs or 
-issues, please consult our [contribution guidelines](https://github.com/nunit/nunit/blob/master/CONTRIBUTING.md).
+Before you report a bug against NUnit, run your tests in the console first. This will help us determine if the bug is with the framework or the test runner you are using.
+
+Bugs, enhancements and feature requests should be entered as issues in the appropriate GitHub repository listed below. Before submitting bugs or issues, please consult our [contribution guidelines](https://github.com/nunit/nunit/blob/master/CONTRIBUTING.md).
 
 ### Issues on GitHub
 
@@ -26,16 +25,14 @@ If you are not sure where to report a particular problem, please ask! If you are
 - [NUnit 3 VS Adapter](http://github.com/nunit/nunit3-vs-adapter/issues)
 - [NUnit Xamarin Runner](http://github.com/nunit/nunit.xamarin/issues)
 - [NUnit Templates](http://github.com/nunit/nunit.templates/issues)
-- [Gui Runner](http://github.com/nunit/nunit-gui/issues)
 - [NUnit VS Adapter](http://github.com/nunit/nunit-vs-adapter/issues)
-- [NUnit Project Editor](http://github.com/nunit/nunit-project-editor/issues)
 
-**Note:** Bugs are no longer accepted on the NUnit V2 and NUnitLite projects. NUnit V2 bugs should be filed against the most appropriate project above and we'll check to see the problem doesn't occur in NUnit 3.0. NUnitLite bugs should be filed against the NUnit Framework, noting that the bug was found in the nunitlite environment.
+**Note:** Bugs are no longer accepted on the NUnit V2 and NUnitLite projects. NUnit V2 bugs should be filed against the most appropriate project above and we'll check to see the problem doesn't occur in NUnit 3. NUnitLite bugs should be filed against the NUnit Framework, noting that the bug was found in the nunitlite environment.
 
 ## <i class="fa fa-comment-o"></i> To discuss or contribute to NUnit development
 
-Start by joining the [nunit-developer list](http://groups.google.com/group/nunit-developer) and introducing yourself. This list is for development discussions about NUnit. 
+Start by joining the [nunit-developer list](http://groups.google.com/group/nunit-developer) and introducing yourself. This list is for development discussions about NUnit.
 It's open to everyone and is the best place to discuss your ideas or to learn how to contribute to NUnit.
 
-You can then read through our [contribution guidelines](https://github.com/nunit/nunit/blob/master/CONTRIBUTING.md) and our 
+You can then read through our [contribution guidelines](https://github.com/nunit/nunit/blob/master/CONTRIBUTING.md) and our
 [developer wiki](https://github.com/nunit/dev/wiki) for more information on getting involved.

--- a/donations.md
+++ b/donations.md
@@ -5,7 +5,7 @@ icon: fa-usd
 permalink: /donations/
 ---
 
-Your donation to NUnit helps us pay for web hosting, making presentations at user events and - of course - continuing 
+Your donation to NUnit helps us pay for web hosting, making presentations at user events and - of course - continuing
 to develop the software itself.
 
 You can make a donation easily through Paypal, by clicking on the 'Donate' button.
@@ -16,8 +16,23 @@ You can make a donation easily through Paypal, by clicking on the 'Donate' butto
 
 We thank the following individuals and companies for their donations to the NUnit project.
 
+### 2016
+
+- MacFarlane Physiotherapy, [www.macfarlanephysio.co.uk](http://www.macfarlanephysio.co.uk)
+- Dzmitry Lahoda
+- Righthand Miha Markic s.p.
+- Erl Egestad
+
 ### 2015
 
+- Jason Walker
+- Bennex E-commerce Ltd, [giftprezzy.com](http://giftprezzy.com)
+- Brandon Ringe
+- Stephen Chownwai
+- Галимова Алсу
+- Justin Klumpp
+- Righthand Miha Markic s.p.
+- Gregory HillsHelmer
 - Bryan & Armstrong Ltd. [bryan-armstrong.com](http://bryan-armstrong.com)
 - Sebastien Guimmara
 - Ian Carson

--- a/download.html
+++ b/download.html
@@ -6,77 +6,406 @@ permalink: /download/
 ---
 
 <div class="row">
-    
-    <div class="col-sm-4">
-        <h3>Download Types</h3>
-        
-        <p>The prefered way to download NUnit is through <a href="https://www.nuget.org/packages/NUnit/">NuGet</a> package manager.</p>
-        
-        <p>NUnit Xamarin Runners are also available through <a href="https://www.nuget.org/packages/nunit.xamarin/">NuGet</a> or 
-        from <a href="https://github.com/nunit/nunit.xamarin/releases">GitHub</a>.  
-        
-        <p>The latest releases of NUnit 3.0 can always be found on the <a href="https://github.com/nunit/nunit/releases">GitHub releases pages</a>.</p>       
-    </div>
-    
-    <div class="col-sm-4">
-        <div class="pull-left"><h3>NUnit 3.0.1</h3></div>
-        <div class="pull-right"><h3><small><i class="fa fa-calendar"></i> 1 Dec 2015</small></h3></div>
-        <div class="clearfix"></div>
-        
-        <table class="table table-condensed table-striped">
-            <tr>
-                <td>MSI</td>
-                <td><a href="https://github.com/nunit/nunit/releases/download/3.0.1/NUnit.3.0.1.msi">NUnit.3.0.1.msi</a></td>
-            </tr>
-            <tr>
-                <td>Bin</td>
-                <td><a href="https://github.com/nunit/nunit/releases/download/3.0.1/NUnit-3.0.1.zip">NUnit-3.0.1.zip</a></td>
-            </tr>
-            <tr>
-                <td>Src</td>
-                <td><a href="https://github.com/nunit/nunit/releases/download/3.0.1/NUnit-3.0.1-src.zip">NUnit-3.0.1-src.zip</a></td>
-            </tr>
-            <tr>
-                <td>SL 5.0</td>
-                <td><a href="https://github.com/nunit/nunit/releases/download/3.0.1/NUnitSL-3.0.1.zip">NUnitSL-3.0.1.zip</a></td>
-            </tr>
-            <tr>
-                <td>CF 3.5</td>
-                <td><a href="https://github.com/nunit/nunit/releases/download/3.0.1/NUnitCF-3.0.1.zip">NUnitCF-3.0.1.zip</a></td>
-            </tr>
-        </table>
-    </div>
-    
-    <div class="col-sm-4">     
-        <div class="pull-left"><h3>NUnit 2.6.4</h3></div>
-        <div class="pull-right"><h3><small><i class="fa fa-calendar"></i> 16 Dec 2014</small></h3></div>
-        <div class="clearfix"></div>
-        
-        <table class="table table-condensed table-striped">
-            <tr>
-                <td>MSI</td>
-                <td><a href="http://github.com/nunit/nunitv2/releases/download/2.6.4/NUnit-2.6.4.msi">NUnit-2.6.4.msi</a></td>
-            </tr>
-            <tr>
-                <td>Bin</td>
-                <td><a href="http://github.com/nunit/nunitv2/releases/download/2.6.4/NUnit-2.6.4.zip">NUnit-2.6.4.zip</a></td>
-            </tr>
-            <tr>
-                <td>Src</td>
-                <td><a href="https://github.com/nunit/nunitv2/archive/2.6.4.zip">2.6.4.zip</a></td>
-            </tr>
-            <tr>
-                <td>MSI .Net 1.1</td>
-                <td><a href="http://github.com/nunit/nunitv2/releases/download/2.6.4/NUnit-2.6.4-net-1.1.msi">NUnit-2.6.4-net-1.1.msi</a></td>
-            </tr>
-            <tr>
-                <td>Zip .Net 1.1</td>
-                <td><a href="http://github.com/nunit/nunitv2/releases/download/2.6.4/NUnit-2.6.4-net-1.1.zip">NUnit-2.6.4-net-1.1.zip</a></td>
-            </tr>
-            <tr>
-                <td>Docs</td>
-                <td><a href="http://github.com/nunit/nunitv2/releases/download/2.6.4/NUnit-2.6.4-docs.zip">NUnit-2.6.4-docs.zip</a></td>
-            </tr>
-        </table>
-    </div>
+
+  <div class="col-sm-6">
+    <h3>Download Types</h3>
+
+    <p>The prefered way to download NUnit is through <a href="https://www.nuget.org/packages/NUnit/">NuGet</a> package manager.</p>
+
+    <p>NUnit Xamarin Runners are also available through <a href="https://www.nuget.org/packages/nunit.xamarin/">NuGet</a> or
+      from <a href="https://github.com/nunit/nunit.xamarin/releases">GitHub</a>.
+
+      <p>The latest releases of NUnit 3.0 can always be found on the <a href="https://github.com/nunit/nunit/releases">GitHub releases pages</a>.</p>
+  </div>
+
+  <div class="col-sm-6">
+    <table class="table table-condensed table-striped">
+      <tr>
+        <th colspan="2">Latest NUnit 3 Releases</th>
+      </tr>
+      <tr>
+        <td><a href="https://github.com/nunit/nunit/releases/latest">NUnit 3.7.1</a></td>
+        <td class="text-right">June 5, 2017</td>
+      </tr>
+      <tr>
+        <td><a href="https://github.com/nunit/nunit-console/releases/latest">NUnit Console 3.6.1</a></td>
+        <td class="text-right">March 6, 2017</td>
+      </tr>
+      <tr>
+        <td><a href="https://github.com/nunit/nunit3-vs-adapter/releases/latest">NUnit Test Adapter 3.4.1</a></td>
+        <td class="text-right">August 3, 2016</td>
+      </tr>
+      <tr>
+        <td><a href="https://github.com/nunit/nunit.xamarin/releases/latest">NUnit Xamarin Runners 3.6.1</a></td>
+        <td class="text-right">March 14, 2017</td>
+      </tr>
+    </table>
+
+    <table class="table table-condensed table-striped">
+      <tr>
+        <th colspan="2">Latest NUnit 2 Release</th>
+      </tr>
+      <tr>
+        <td><a href="https://github.com/nunit/nunitv2/releases/latest">NUnit 2.6.4</a></td>
+        <td class="text-right">December 16, 2014</td>
+      </tr>
+      <tr>
+        <td><a href="https://github.com/nunit/nunit-vs-adapter/releases/latest">NUnit Test Adapter 2.0</a></td>
+        <td class="text-right">April 1, 2015</td>
+      </tr>
+    </table>
+  </div>
+</div>
+
+<hr />
+
+<h2>Older Releases</h2>
+<p>These releases are needed by many people for legacy work, so we keep them around for download. Bugs are accepted on older
+  releases only if they can be reproduced on a current release.</p>
+
+<div class="col-sm-6">
+  <table class="table table-condensed table-striped">
+    <tr>
+      <th colspan="2">NUnit 3</th>
+    </tr>
+    <tr>
+      <td><a href="https://github.com/nunit/nunit/releases/3.7">NUnit 3.7</a></td>
+      <td class="text-right">May 29, 2017</td>
+    </tr>
+    <tr>
+      <td><a href="https://github.com/nunit/nunit/releases/3.6.1">NUnit 3.6.1</a></td>
+      <td class="text-right">February 26, 2017</td>
+    </tr>
+    <tr>
+      <td><a href="https://github.com/nunit/nunit/releases/3.6">NUnit 3.6</a></td>
+      <td class="text-right">January 9, 2017</td>
+    </tr>
+    <tr>
+      <td><a href="https://github.com/nunit/nunit/releases/3.5">NUnit 3.5</a></td>
+      <td class="text-right">October 3, 2016</td>
+    </tr>
+    <tr>
+      <td><a href="https://github.com/nunit/nunit/releases/3.4.1">NUnit 3.4.1</a></td>
+      <td class="text-right">June 30, 2016</td>
+    </tr>
+    <tr>
+      <td><a href="https://github.com/nunit/nunit/releases/3.4">NUnit 3.4</a></td>
+      <td class="text-right">June 25, 2016</td>
+    </tr>
+    <tr>
+      <td><a href="https://github.com/nunit/nunit/releases/3.2.1">NUnit 3.2.1</a></td>
+      <td class="text-right">April 19, 2016</td>
+    </tr>
+    <tr>
+      <tr>
+        <td><a href="https://github.com/nunit/nunit/releases/3.2.0">NUnit 3.2</a></td>
+        <td class="text-right">March 5, 2016</td>
+      </tr>
+      <tr>
+        <td><a href="https://github.com/nunit/nunit/releases/3.0.1">NUnit 3.0.1</a></td>
+        <td class="text-right">December 1, 2015</td>
+      </tr>
+      <tr>
+        <td><a href="https://github.com/nunit/nunit/releases/3.0.0">NUnit 3.0</a></td>
+        <td class="text-right">November 15, 2015</td>
+      </tr>
+      <tr>
+        <td><a href="https://github.com/nunit/nunit/releases/3.0.0-rc3">NUnit 3.0 RC 3</a></td>
+        <td class="text-right">November 13, 2015</td>
+      </tr>
+      <tr>
+        <td><a href="https://github.com/nunit/nunit/releases/3.0.0-rc2">NUnit 3.0 RC 2</a></td>
+        <td class="text-right">November 8, 2015</td>
+      </tr>
+      <tr>
+        <td><a href="https://github.com/nunit/nunit/releases/3.0.0-rc">NUnit 3.0 RC</a></td>
+        <td class="text-right">November 1, 2015</td>
+      </tr>
+      <tr>
+        <td><a href="https://github.com/nunit/nunit/releases/3.0.0-beta-5">NUnit 3.0 Beta 5</a></td>
+        <td class="text-right">October 16, 2015</td>
+      </tr>
+      <tr>
+        <td><a href="https://github.com/nunit/nunit/releases/3.0.0-beta-4">NUnit 3.0 Beta 4</a></td>
+        <td class="text-right">August 25, 2015</td>
+      </tr>
+      <tr>
+        <td><a href="https://github.com/nunit/nunit/releases/3.0.0-beta-3">NUnit 3.0 Beta 3</a></td>
+        <td class="text-right">July 15, 2015</td>
+      </tr>
+      <tr>
+        <td><a href="https://github.com/nunit/nunit/releases/3.0.0-beta-2">NUnit 3.0 Beta 2</a></td>
+        <td class="text-right">May 12, 2015</td>
+      </tr>
+      <tr>
+        <td><a href="https://github.com/nunit/nunit/releases/3.0.0-beta-1">NUnit 3.0 Beta 1</a></td>
+        <td class="text-right">March 25, 2015</td>
+      </tr>
+      <tr>
+        <td><a href="https://github.com/nunit/nunit/releases/3.0.0-alpha-4">NUnit 3.0 Alpha 4</a></td>
+        <td class="text-right">December 30, 2014</td>
+      </tr>
+      <tr>
+        <td><a href="https://github.com/nunit/nunit/releases/3.0.0-alpha-3">NUnit 3.0 Alpha 3</a></td>
+        <td class="text-right">November 29, 2014</td>
+      </tr>
+      <tr>
+        <td><a href="https://github.com/nunit/nunit/releases/3.0.0-alpha-2">NUnit 3.0 Alpha 2</a></td>
+        <td class="text-right">November 2, 2014</td>
+      </tr>
+      <tr>
+        <td><a href="https://github.com/nunit/nunit/releases/3.0.0-alpha">NUnit 3.0 Alpha</a></td>
+        <td class="text-right">September 22, 2014</td>
+      </tr>
+  </table>
+
+  <table class="table table-condensed table-striped">
+    <tr>
+      <th colspan="2">NUnit 3 Console</th>
+    </tr>
+    <tr>
+      <td><a href="https://github.com/nunit/nunit-console/releases/tag/3.6">NUnit Console 3.6</a></td>
+      <td class="text-right">January 14, 2017</td>
+    </tr>
+    <tr>
+      <td><a href="https://github.com/nunit/nunit-console/releases/tag/3.5">NUnit Console 3.5</a></td>
+      <td class="text-right">October 11, 2016</td>
+    </tr>
+  </table>
+</div>
+
+<div class="col-sm-6">
+  <table class="table table-condensed table-striped">
+    <tr>
+      <th colspan="2">NUnit 2</th>
+    </tr>
+    <tr>
+      <td><a href="http://launchpad.net/nunitv2/trunk/2.6.3">NUnit 2.6.3</a></td>
+      <td class="text-right">October 10, 2013</td>
+    </tr>
+    <tr>
+      <td><a href="http://launchpad.net/nunitv2/trunk/2.6.2">NUnit 2.6.2</a></td>
+      <td class="text-right">October 22, 2012</td>
+    </tr>
+    <tr>
+      <td><a href="http://launchpad.net/nunitv2/trunk/2.6.1">NUnit 2.6.1</a></td>
+      <td class="text-right">August 4, 2012</td>
+    </tr>
+    <tr>
+      <td><a href="http://launchpad.net/nunitv2/trunk/2.6.1rc2">NUnit 2.6.1 RC 2</a></td>
+      <td class="text-right">July 26, 2012</td>
+    </tr>
+    <tr>
+      <td><a href="http://launchpad.net/nunitv2/trunk/2.6.1rc">NUnit 2.6.1 RC 1</a></td>
+      <td class="text-right">July 10, 2012</td>
+    </tr>
+    <tr>
+      <td><a href="http://launchpad.net/nunitv2/trunk/2.6.0">NUnit 2.6.0</a></td>
+      <td class="text-right">February 20, 2012</td>
+    </tr>
+    <tr>
+      <td><a href="http://launchpad.net/nunitv2/trunk/2.6.0rc">NUnit 2.6.0 RC</a></td>
+      <td class="text-right">February 4, 2012</td>
+    </tr>
+    <tr>
+      <td><a href="http://launchpad.net/nunitv2/trunk/2.6.0b4">NUnit 2.6.0 Beta 4</a></td>
+      <td class="text-right">January 17, 2012</td>
+    </tr>
+    <tr>
+      <td><a href="http://launchpad.net/nunitv2/trunk/2.6.0b3">NUnit 2.6.0 Beta 3</a></td>
+      <td class="text-right">December 6, 2011</td>
+    </tr>
+    <tr>
+      <td><a href="http://launchpad.net/nunitv2/trunk/2.6.0b2">NUnit 2.6.0 Beta 2</a></td>
+      <td class="text-right">November 20, 2011</td>
+    </tr>
+    <tr>
+      <td><a href="http://launchpad.net/nunitv2/trunk/2.6.0b1">NUnit 2.6.0 Beta 1</a></td>
+      <td class="text-right">Aubust 28, 2011</td>
+    </tr>
+    <tr>
+      <td><a href="http://launchpad.net/nunitv2/2.5/2.5.10">NUnit 2.5.10</a></td>
+      <td class="text-right">April 2, 2011</td>
+    </tr>
+    <tr>
+      <td><a href="http://launchpad.net/nunitv2/2.5/2.5.9">NUnit 2.5.9</a></td>
+      <td class="text-right">December 14, 2010</td>
+    </tr>
+    <tr>
+      <td><a href="http://launchpad.net/nunitv2/2.5/2.5.8">NUnit 2.5.8</a></td>
+      <td class="text-right">October 22, 2010</td>
+    </tr>
+    <tr>
+      <td><a href="http://launchpad.net/nunitv2/2.5/2.5.7">NUnit 2.5.7</a></td>
+      <td class="text-right">August 1, 2010</td>
+    </tr>
+    <tr>
+      <td><a href="http://launchpad.net/nunitv2/2.5/2.5.6">NUnit 2.5.6</a></td>
+      <td class="text-right">July 24, 2010</td>
+    </tr>
+    <tr>
+      <td><a href="http://launchpad.net/nunitv2/2.5/2.5.5">NUnit 2.5.5</a></td>
+      <td class="text-right">April 22, 2010</td>
+    </tr>
+    <tr>
+      <td><a href="http://launchpad.net/nunitv2/2.5/2.5.4">NUnit 2.5.4</a></td>
+      <td class="text-right">April 8, 2010</td>
+    </tr>
+    <tr>
+      <td><a href="http://launchpad.net/nunitv2/2.5/2.5.3">NUnit 2.5.3</a></td>
+      <td class="text-right">December 11, 2009</td>
+    </tr>
+    <tr>
+      <td><a href="https://sourceforge.net/projects/nunit/files/NUnit%20Version%202/V2.5.2/">NUnit 2.5.2</a></td>
+      <td class="text-right">August 10, 2009</td>
+    </tr>
+    <tr>
+      <td><a href="https://sourceforge.net/projects/nunit/files/NUnit%20Version%202/V2.5.1/">NUnit 2.5.1</a></td>
+      <td class="text-right">July 8, 2009</td>
+    </tr>
+    <tr>
+      <td><a href="https://sourceforge.net/projects/nunit/files/NUnit%20Version%202/V2.5/">NUnit 2.5</a></td>
+      <td class="text-right">May 3, 2009</td>
+    </tr>
+    <tr>
+      <td><a href="https://sourceforge.net/projects/nunit/files/NUnit%20Version%202/V2.5%20RC%201/">NUnit 2.5 RC 1</a></td>
+      <td class="text-right">April 28, 2009</td>
+    </tr>
+    <tr>
+      <td><a href="https://sourceforge.net/projects/nunit/files/NUnit%20Version%202/V2.5%20Beta%203/">NUnit 2.5 Beta 3</a></td>
+      <td class="text-right">April 7, 2009</td>
+    </tr>
+    <tr>
+      <td><a href="https://sourceforge.net/projects/nunit/files/NUnit%20Version%202/V2.5%20Beta%202/">NUnit 2.5 Beta 2</a></td>
+      <td class="text-right">January 16, 2009</td>
+    </tr>
+    <tr>
+      <td><a href="https://sourceforge.net/projects/nunit/files/NUnit%20Version%202/V2.5%20Beta%201/">NUnit 2.5 Beta 1</a></td>
+      <td class="text-right">November 28, 2008</td>
+    </tr>
+    <tr>
+      <td><a href="https://sourceforge.net/projects/nunit/files/NUnit%20Version%202/V2.5%20Alpha-4/">NUnit 2.5 Alpha 4</a></td>
+      <td class="text-right">September 15, 2008</td>
+    </tr>
+    <tr>
+      <td><a href="https://sourceforge.net/projects/nunit/files/NUnit%20Version%202/V2.5%20Alpha%203/">NUnit 2.5 Alpha 3</a></td>
+      <td class="text-right">July 8, 2008</td>
+    </tr>
+    <tr>
+      <td><a href="https://sourceforge.net/projects/nunit/files/NUnit%20Version%202/V2.5%20Alpha%202/">NUnit 2.5 Alpha 2</a></td>
+      <td class="text-right">May 7, 2008</td>
+    </tr>
+    <tr>
+      <td><a href="https://sourceforge.net/projects/nunit/files/NUnit%20Version%202/V2.5%20Alpha%201/">NUnit 2.5 Alpha 1</a></td>
+      <td class="text-right">April 19, 2008</td>
+    </tr>
+    <tr>
+      <td><a href="https://sourceforge.net/projects/nunit/files/NUnit%20Version%202/V2.4.8/">NUnit 2.4.8</a></td>
+      <td class="text-right">July 21, 2008</td>
+    </tr>
+    <tr>
+      <td><a href="https://sourceforge.net/projects/nunit/files/NUnit%20Version%202/V2.4.7/">NUnit 2.4.7</a></td>
+      <td class="text-right">March 30, 2008</td>
+    </tr>
+    <tr>
+      <td><a href="https://sourceforge.net/projects/nunit/files/NUnit%20Version%202/V2.4.6/">NUnit 2.4.6</a></td>
+      <td class="text-right">December 31, 2007</td>
+    </tr>
+    <tr>
+      <td><a href="https://sourceforge.net/projects/nunit/files/NUnit%20Version%202.4.5/V2.4.5/">NUnit 2.4.5</a></td>
+      <td class="text-right">November 23, 2007</td>
+    </tr>
+    <tr>
+      <td><a href="https://sourceforge.net/projects/nunit/files/NUnit%20Version%202/V2.4.4/">NUnit 2.4.4</a></td>
+      <td class="text-right">October 21, 2007</td>
+    </tr>
+    <tr>
+      <td><a href="https://sourceforge.net/projects/nunit/files/NUnit%20Version%202/V2.4.3/">NUnit 2.4.3</a></td>
+      <td class="text-right">August 17, 2007</td>
+    </tr>
+    <tr>
+      <td><a href="https://sourceforge.net/projects/nunit/files/NUnit%20Version%202/V2.4.2/">NUnit 2.4.2</a></td>
+      <td class="text-right">August 7, 2007</td>
+    </tr>
+    <tr>
+      <td><a href="https://sourceforge.net/projects/nunit/files/NUnit%20Version%202/V2.4.1/">NUnit 2.4.1</a></td>
+      <td class="text-right">July 17, 2007</td>
+    </tr>
+    <tr>
+      <td><a href="https://sourceforge.net/projects/nunit/files/NUnit%20Version%202/V2.4/">NUnit 2.4</a></td>
+      <td class="text-right">March 16, 2007</td>
+    </tr>
+    <tr>
+      <td>NUnit 2.4 RC 2 <i>(Unavailable)</i></td>
+      <td class="text-right">March 9, 2007</td>
+    </tr>
+    <tr>
+      <td>NUnit 2.4 RC 1 <i>(Unavailable)</i></td>
+      <td class="text-right">February 25, 2007</td>
+    </tr>
+    <tr>
+      <td>NUnit 2.4 Beta 2 <i>(Unavailable)</i></td>
+      <td class="text-right">October 20, 2006</td>
+    </tr>
+    <tr>
+      <td>NUnit 2.4 Beta 1 <i>(Unavailable)</i></td>
+      <td class="text-right">June 11, 2006</td>
+    </tr>
+    <tr>
+      <td>NUnit 2.4 Alpha <i>(Unavailable)</i></td>
+      <td class="text-right">May 22, 2006</td>
+    </tr>
+    <tr>
+      <td><a href="https://sourceforge.net/projects/nunit/files/NUnit%20Version%202/V2.2.10/">NUnit 2.2.10</a></td>
+      <td class="text-right">March 15, 2007</td>
+    </tr>
+    <tr>
+      <td><a href="https://sourceforge.net/projects/nunit/files/NUnit%20Version%202/V2.2.9/">NUnit 2.2.9</a></td>
+      <td class="text-right">November 26, 2006</td>
+    </tr>
+    <tr>
+      <td><a href="https://sourceforge.net/projects/nunit/files/NUnit%20Version%202/V2.2.8/">NUnit 2.2.8</a></td>
+      <td class="text-right">April 21, 2006</td>
+    </tr>
+    <tr>
+      <td><a href="https://sourceforge.net/projects/nunit/files/NUnit%20Version%202/V2.2.7/">NUnit 2.2.7</a></td>
+      <td class="text-right">February 18, 2006</td>
+    </tr>
+    <tr>
+      <td><a href="https://sourceforge.net/projects/nunit/files/NUnit%20Version%202/V2.2.6/">NUnit 2.2.6</a></td>
+      <td class="text-right">January 21, 2006</td>
+    </tr>
+    <tr>
+      <td><a href="https://sourceforge.net/projects/nunit/files/NUnit%20Version%202/V2.2.5/">NUnit 2.2.5</a></td>
+      <td class="text-right">December 22, 2005</td>
+    </tr>
+    <tr>
+      <td><a href="https://sourceforge.net/projects/nunit/files/NUnit%20Version%202/V2.2.4/">NUnit 2.2.4</a></td>
+      <td class="text-right">December 14, 2005</td>
+    </tr>
+    <tr>
+      <td>NUnit 2.2.3 <i>(Unavailable)</i></td>
+      <td class="text-right">November 14, 2005</td>
+    </tr>
+    <tr>
+      <td>NUnit 2.2.2 <i>(Unavailable)</i></td>
+      <td class="text-right">December 7, 2004</td>
+    </tr>
+    <tr>
+      <td>NUnit 2.2.1 <i>(Unavailable)</i></td>
+      <td class="text-right">October 26, 2004</td>
+    </tr>
+    <tr>
+      <td><a href="https://sourceforge.net/projects/nunit/files/NUnit%20Version%202/V2.2/">NUnit 2.2</a></td>
+      <td class="text-right">February 18, 2004</td>
+    </tr>
+    <tr>
+      <td><a href="https://sourceforge.net/projects/nunit/files/NUnit%20Version%202/V2.1/">NUnit 2.1</a></td>
+      <td class="text-right">September 1, 2003</td>
+    </tr>
+    <tr>
+      <td><a href="https://sourceforge.net/projects/nunit/files/NUnit%20Version%202/V2.0/">NUnit 2.0</a></td>
+      <td class="text-right">October 3, 2002</td>
+    </tr>
+  </table>
 </div>

--- a/download.html
+++ b/download.html
@@ -15,7 +15,7 @@ permalink: /download/
     <p>NUnit Xamarin Runners are also available through <a href="https://www.nuget.org/packages/nunit.xamarin/">NuGet</a> or
       from <a href="https://github.com/nunit/nunit.xamarin/releases">GitHub</a>.
 
-      <p>The latest releases of NUnit 3.0 can always be found on the <a href="https://github.com/nunit/nunit/releases">GitHub releases pages</a>.</p>
+      <p>The latest releases of NUnit 3 can always be found on the <a href="https://github.com/nunit/nunit/releases">GitHub releases pages</a>.</p>
   </div>
 
   <div class="col-sm-6">

--- a/index.html
+++ b/index.html
@@ -7,10 +7,10 @@ layout: default
       <div class="col-sm-4">
         <object data="/img/nunit_logo.svg" type="image/svg+xml" height="128">
           <img src="/img/nunit_logo_128.png" />
-        </object>        
+        </object>
       </div>
       <div class="col-sm-6">
-            
+
       </div>
       <div class="col-sm-2">
         <a class="btn btn-danger btn-lg" href="/download/" role="button">Download <i class="fa fa-download"></i></a>
@@ -24,45 +24,45 @@ layout: default
         <div class="row">
             <div class="col-sm-12">
                 <h2><i class="fa fa-info-circle"></i> What Is NUnit?</h2>
-                
+
                 <p>NUnit is a unit-testing framework for all .Net languages. Initially ported from <a href="http://www.junit.org/">JUnit</a>, the current
-                    production release, version 3.0, has been completely rewritten with many new features and support for a wide range of
-                    .NET platforms.</p>            
+                    production release, version 3, has been completely rewritten with many new features and support for a wide range of
+                    .NET platforms.</p>
             </div>
         </div>
-        
+
         <div class="row">
-            
+
             <div class="col-sm-4">
                 <h2><i class="fa fa-check-square-o"></i> License</h2>
-                
-                <p>NUnit is Open Source software and NUnit 3.0 is released under the <a href="/nuget/nunit3-license.txt">MIT license</a>. Earlier releases
+
+                <p>NUnit is Open Source software and NUnit 3 is released under the <a href="/nuget/nunit3-license.txt">MIT license</a>. Earlier releases
                     used the <a href="/nuget/license.html">NUnit license</a>.</p>
-                    
+
                 <p>Both of these licenses allow the use of NUnit in free and commercial applications
                     and libraries without restrictions.</p>
             </div>
-            
+
             <div class="col-sm-4">
                 <h2><i class="fa fa-user"></i> About Us</h2>
-                
-                <p>NUnit 3.0 was created by <a href="http://www.charliepoole.org/">Charlie Poole</a>, <a href="http://www.alteridem.net/">Rob Prouse</a>, 
+
+                <p>NUnit 3 was created by <a href="http://www.charliepoole.org/">Charlie Poole</a>, <a href="http://www.alteridem.net/">Rob Prouse</a>,
                 <a href="http://simoneb.github.io/">Simone Busoli</a>, Neil Colvin and numerous community contributors.</p>
-                
-                <p>Earlier versions of NUnit were developed by Charlie Poole, James Newkirk, Alexei Vorontsov, Michael Two and Philip Craig.</p>            
+
+                <p>Earlier versions of NUnit were developed by Charlie Poole, James Newkirk, Alexei Vorontsov, Michael Two and Philip Craig.</p>
             </div>
-                    
+
             <div class="col-sm-4">
                 <h2><i class="fa fa-usd"></i> Donations</h2>
-                
+
                 <p>The NUnit team invests a great deal of time and effort to make NUnit a useful tool. In addition, we have expenses. We have
                     to purchase domain names, arrange for web site hosting and acquire equipment.</p>
-                
+
                 <p>Financial contributions are one way you can help to ensure that NUnit continues to develop and remains free
                     and open software. For more information or to view a list of donors, see our <a href="/donations/">Donations</a> page.</p>
-                    
+
                 <p> {% include paypal.html %} </p>
-                
+
             </div>
         </div>
     </div>

--- a/news.html
+++ b/news.html
@@ -9,14 +9,18 @@ permalink: /news/
 
     <h1><i class="fa fa-commenting-o"></i> News</h1>
 
-    <ul>
-      {% for post in site.posts %}
-      <li>
-        <span>{{ post.date | date: "%b %-d, %Y" }}</span>
-        <a href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
-      </li>
-      {% endfor %}
-    </ul>
+    <div class="row">
+      <div class="col-sm-6">
+        <table class="table table-condensed table-striped">
+          {% for post in site.posts %}
+          <tr>
+            <td><span>{{ post.date | date: "%b %-d, %Y" }}</span></td>
+            <td><a href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a></td>
+          </tr>
+          {% endfor %}
+        </table>
+      </div>
+    </div>
 
     <p>subscribe <a href="{{ " /feed.xml " | prepend: site.baseurl }}">via RSS</a></p>
 


### PR DESCRIPTION
Fixes #3 

All content on the site is now included in this site and it has been updated to its latest version except for the legacy documentation which is covered by #4.

All downloads link to the same location as before which is not on nunit.org.

I only imported the last three news items. They are also not currently displayed on the front page, but instead they are linked from a news page. The news page and the linked posts can be used in the future for longer form announcements and blog style posts.

Except for the documentation, I think this is ready to go. We could even decide to switch over DNS once this is merged and migrate the documentation as soon as we can. Maybe just switch nunit.org over for now and leave nunit.com up so people can access the legacy documentation until I finish the migration?