### PR TITLE
Add recent donations

### DIFF
--- a/donations.md
+++ b/donations.md
@@ -16,8 +16,19 @@ You can make a donation easily through Paypal, by clicking on the 'Donate' butto
 
 We thank the following individuals and companies for their donations to the NUnit project.
 
+### 2017
+
+- Graham Wilson
+- Michal Bieszczad
+- Mighty IT (Pty) Ltd
+
 ### 2016
 
+- Ben Chenathara
+- John Burak
+- Himanshu Saxena
+- Dot Media
+- Yevgeniy Mayskiy
 - MacFarlane Physiotherapy, [www.macfarlanephysio.co.uk](http://www.macfarlanephysio.co.uk)
 - Dzmitry Lahoda
 - Righthand Miha Markic s.p.

--- a/index.html
+++ b/index.html
@@ -61,8 +61,6 @@ layout: default
                 <p>Financial contributions are one way you can help to ensure that NUnit continues to develop and remains free
                     and open software. For more information or to view a list of donors, see our <a href="/donations/">Donations</a> page.</p>
 
-                <p> {% include paypal.html %} </p>
-
             </div>
         </div>
     </div>


### PR DESCRIPTION
Fixes #9 

Adds the recent donations that were not on the page. Also deletes the donation button from the front page as discussed in the governance repo. I left it in the donations page, we will still need to rework the entire donations so the governance issue can remain open.