### PR TITLE
Update the adapter release and link to Gitter

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -20,6 +20,7 @@
             <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
+            <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>
         </ul>
     </div><!--/.nav-collapse -->

--- a/download.html
+++ b/download.html
@@ -32,8 +32,8 @@ permalink: /download/
         <td class="text-right">March 6, 2017</td>
       </tr>
       <tr>
-        <td><a href="https://github.com/nunit/nunit3-vs-adapter/releases/latest">NUnit Test Adapter 3.4.1</a></td>
-        <td class="text-right">August 3, 2016</td>
+        <td><a href="https://github.com/nunit/nunit3-vs-adapter/releases/latest">NUnit Test Adapter 3.7</a></td>
+        <td class="text-right">January 26, 2017</td>
       </tr>
       <tr>
         <td><a href="https://github.com/nunit/nunit.xamarin/releases/latest">NUnit Xamarin Runners 3.6.1</a></td>
@@ -50,8 +50,8 @@ permalink: /download/
         <td class="text-right">December 16, 2014</td>
       </tr>
       <tr>
-        <td><a href="https://github.com/nunit/nunit-vs-adapter/releases/latest">NUnit Test Adapter 2.0</a></td>
-        <td class="text-right">April 1, 2015</td>
+        <td><a href="https://github.com/nunit/nunit-vs-adapter/releases/latest">NUnit Test Adapter 2.1.1</a></td>
+        <td class="text-right">March 19, 2017</td>
       </tr>
     </table>
   </div>


### PR DESCRIPTION
Fixes #10 
Fixes #8

I updated the v2 and v3 adapters to the latest release. While I was at it, I added the link to Gitter to the header. For now, I used a comment icon for Gitter. The header uses Font Awesome icons for each link, so a PNG of the logo would probably suck. FA 5 will be out soon with many more icons. Hopefully it will contain the Gitter logo.

![image](https://user-images.githubusercontent.com/493828/28163936-0d4c6276-679b-11e7-9247-ae37e5fd30a3.png)
