### PR TITLE
Add the 3.8 console release and make the older releases collapsible.

### DIFF
--- a/download.html
+++ b/download.html
@@ -28,8 +28,8 @@ permalink: /download/
         <td class="text-right">November 10, 2017</td>
       </tr>
       <tr>
-        <td><a href="https://github.com/nunit/nunit-console/releases/latest">NUnit Console 3.7</a></td>
-        <td class="text-right">July 13, 2017</td>
+        <td><a href="https://github.com/nunit/nunit-console/releases/latest">NUnit Console 3.8</a></td>
+        <td class="text-right">January 27, 2017</td>
       </tr>
       <tr>
         <td><a href="https://github.com/nunit/nunit3-vs-adapter/releases/latest">NUnit Test Adapter 3.8</a></td>
@@ -59,10 +59,11 @@ permalink: /download/
 
 <hr />
 
-<h2>Older Releases</h2>
+<h2><a role="button" data-toggle="collapse" data-target="#olderReleases" href="#olderReleases">Older Releases</a></h2>
 <p>These releases are needed by many people for legacy work, so we keep them around for download. Bugs are accepted on older
   releases only if they can be reproduced on a current release.</p>
 
+<div class="row collapse" id="olderReleases">
 <div class="col-sm-6">
   <table class="table table-condensed table-striped">
     <tr>
@@ -175,10 +176,14 @@ permalink: /download/
     <tr>
       <th colspan="2">NUnit 3 Console</th>
     </tr>
-      <tr>
-        <td><a href="https://github.com/nunit/nunit-console/releases/tag/3.6.1">NUnit Console 3.6.1</a></td>
-        <td class="text-right">March 6, 2017</td>
-      </tr>
+    <tr>
+      <td><a href="https://github.com/nunit/nunit-console/releases/tag/3.7">NUnit Console 3.7</a></td>
+      <td class="text-right">July 13, 2017</td>
+    </tr>
+    <tr>
+      <td><a href="https://github.com/nunit/nunit-console/releases/tag/3.6.1">NUnit Console 3.6.1</a></td>
+      <td class="text-right">March 6, 2017</td>
+    </tr>
     <tr>
       <td><a href="https://github.com/nunit/nunit-console/releases/tag/3.6">NUnit Console 3.6</a></td>
       <td class="text-right">January 14, 2017</td>
@@ -424,4 +429,5 @@ permalink: /download/
       <td class="text-right">October 3, 2002</td>
     </tr>
   </table>
+</div>
 </div>


### PR DESCRIPTION
The older releases is getting really long, so I put it in a collapsed div and expand by clicking on the Older Releases. Simple bootstrap...