### PR TITLE
Update the copyright for all legacy documentation

### DIFF
--- a/_includes/help_footer.html
+++ b/_includes/help_footer.html
@@ -1,0 +1,17 @@
+<footer class="footer">
+  <div class="container">
+    <div class="row text-muted">
+      <div class="col-sm-8">
+        NUnit 2 Documentation Copyright &copy; 2014, Charlie Poole. All rights reserved.
+      </div>
+      <div class="col-sm-4">
+        <p class="text-right">
+          Supported by the
+          <a href="https://dotnetfoundation.org/">.NET Foundation</a>
+        </p>
+      </div>
+    </div>
+  </div>
+</footer>
+
+{% include scripts.html %}

--- a/_layouts/help.html
+++ b/_layouts/help.html
@@ -17,7 +17,7 @@
   <script src="/js/jquery.min.js"></script>
   <script src="/js/codeFuncs.js"></script>
 
-    {% include footer.html %}
+    {% include help_footer.html %}
 
   </body>
 </html>


### PR DESCRIPTION
Fixes #47 

This changes the footer for the legacy docs to be only copyright @CharliePoole, to not be Creative Commons and instead be All Rights Reserved.