### PR TITLE
fixing footer markup

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -4,19 +4,15 @@
       <div class="col-sm-4">
         Copyright &copy; 2017, Charlie Poole, Rob Prouse.
       </div>
-      <div class="col-sm-4">
-          <p class="text-center">
-          <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/4.0/">CC BY-NC-SA 4.0 License</a>
-          <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/4.0/">
-            <img alt="Creative Commons License" src="https://i.creativecommons.org/l/by-nc-sa/4.0/80x15.png" />
-          </a>
-        </p>
+      <div class="col-sm-4 text-center">
+        <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/4.0/">CC BY-NC-SA 4.0 License</a>
+        <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/4.0/">
+          <img alt="Creative Commons License" src="https://i.creativecommons.org/l/by-nc-sa/4.0/80x15.png" />
+        </a>
       </div>
-      <div class="col-sm-4">
-        <p class="text-right">
-          Supported by the
-          <a href="https://dotnetfoundation.org/">.NET Foundation</a>
-        </p>
+      <div class="col-sm-4 text-right">
+        Supported by the
+        <a href="https://dotnetfoundation.org/">.NET Foundation</a>
       </div>
     </div>
   </div>

--- a/_includes/help_footer.html
+++ b/_includes/help_footer.html
@@ -4,11 +4,9 @@
       <div class="col-sm-8">
         NUnit 2 Documentation Copyright &copy; 2014, Charlie Poole. All rights reserved.
       </div>
-      <div class="col-sm-4">
-        <p class="text-right">
-          Supported by the
-          <a href="https://dotnetfoundation.org/">.NET Foundation</a>
-        </p>
+      <div class="col-sm-4 text-right">
+        Supported by the
+        <a href="https://dotnetfoundation.org/">.NET Foundation</a>
       </div>
     </div>
   </div>

--- a/css/main.scss
+++ b/css/main.scss
@@ -57,7 +57,7 @@ $color-complement-4: #2A0200;
 // Pages
 //==============================
 body > div.container {
-    padding-top: 30px;
+  flex: 1 0 auto; /* Prevent Chrome, Opera, and Safari from letting these items shrink to smaller than their content's default minimum size. */
 }
 
 //==============================
@@ -90,16 +90,21 @@ html {
 }
 
 body {
-  /* Margin bottom by footer height */
-  margin-bottom: 50px;
+  display: flex;
+  flex-direction: column;
+  height: 100vh; /* Avoid the IE 10-11 `min-height` bug. */
 }
 
 .footer {
-  position: absolute;
-  bottom: 0;
-  width: 100%;
-  /* Set the fixed height of the footer here */
+  flex-shrink: 0; /* Prevent Chrome, Opera, and Safari from letting these items shrink to smaller than their content's default minimum size. */
+
+  display: flex;
+  flex-direction: row;
+  justify-self: flex-end;
+  justify-content: flex-start;
+  align-items: center;
   height: 50px;
+
   background-color: $color-secondary-1-4;
 }
 
@@ -109,7 +114,6 @@ body {
 }
 
 .container .text-muted {
-  margin: 15px 0;
   color: lighten($gray-base, 77.7%);
 }
 
@@ -138,9 +142,18 @@ pre.prettyprint {
 }
 
 /* Submenu */
-#subnav { position: absolute; top: 100px; left: 76%; background-color: #ffd;
-          width: 24%; margin: 1em 0 0; padding: .25em ; border: solid #ccc;
-          border-width: .1em .1em .1em .1em; }
+#subnav {
+  position: absolute;
+  top: 100px;
+  left: 76%;
+  background-color: #ffd;
+  width: 24%;
+  margin: 1em 0 0;
+  padding: .25em ;
+  border: solid #ccc;
+  border-width: .1em .1em .1em .1em;
+}
+
 #subnav ul { margin: 0; padding: 0; list-style: none; }
 #subnav li{ margin: 0; padding: 2px 0 2px; }
 #subnav a { font: 1em "Times New Roman", Roman, serif; margin: 0; padding: 0 0 0 26px;


### PR DESCRIPTION
Fixing issue #32.
Please, review markup changes. It seems to look better.
Here I'm used flexbox markup (IE9+) for sticky header and footer ([from here](https://css-tricks.com/couple-takes-sticky-footer/#article-header-id-3)). Center content may vary in size, but when content height is less than viewport height, header and footer will stick to top and bottom.

Tricky part was to find that `<p>` has style with `margin-bottom: 10px`. You definitely should not use `<p>` in the footer :)