### PR TITLE
Update the Console 3.9 release and other missed releases

### DIFF
--- a/_posts/2018-09-05-nunit-console-3.9.md
+++ b/_posts/2018-09-05-nunit-console-3.9.md
@@ -1,0 +1,11 @@
+---
+layout: post
+title:  "NUnit Console and Engine 3.9 Released"
+date:   2018-09-05 12:00:00 -0000
+categories: news update nunit
+---
+This release should stop the dreaded SocketException problem on shutdown. The console also no longer returns -5 when AppDomains fail to unload at the end of a test run. These fixes should make CI runs much more stable and predictible.
+
+For developers working on the NUnit Console and Engine project, Visual Studio 2017 update 5 or newer is now required to compile on the command line. This does not effect developers using NUnit or the NUnit Console, both of which support building and running your tests in any IDE and on any .NET Framework back to .NET 2.0.
+
+You may download NUnit Console 3.9 from [Github](https://github.com/nunit/nunit-console/releases). See the [release notes](https://github.com/nunit/docs/wiki/Console-Release-Notes) for more information.

--- a/download.html
+++ b/download.html
@@ -28,12 +28,12 @@ permalink: /download/
         <td class="text-right">March 12, 2018</td>
       </tr>
       <tr>
-        <td><a href="https://github.com/nunit/nunit-console/releases/latest">NUnit Console 3.8</a></td>
-        <td class="text-right">January 27, 2017</td>
+        <td><a href="https://github.com/nunit/nunit-console/releases/latest">NUnit Console 3.9</a></td>
+        <td class="text-right">September 5, 2018</td>
       </tr>
       <tr>
-        <td><a href="https://github.com/nunit/nunit3-vs-adapter/releases/latest">NUnit Test Adapter 3.8</a></td>
-        <td class="text-right">July 19, 2017</td>
+        <td><a href="https://github.com/nunit/nunit3-vs-adapter/releases/latest">NUnit Test Adapter 3.10</a></td>
+        <td class="text-right">March 7, 2018</td>
       </tr>
       <tr>
         <td><a href="https://github.com/nunit/nunit.xamarin/releases/latest">NUnit Xamarin Runners 3.6.1</a></td>
@@ -46,8 +46,8 @@ permalink: /download/
         <th colspan="2">Latest NUnit 2 Release</th>
       </tr>
       <tr>
-        <td><a href="https://github.com/nunit/nunitv2/releases/latest">NUnit 2.6.4</a></td>
-        <td class="text-right">December 16, 2014</td>
+        <td><a href="https://github.com/nunit-legacy/nunitv2/releases">NUnit 2.7.0</a></td>
+        <td class="text-right">August 10, 2018</td>
       </tr>
       <tr>
         <td><a href="https://github.com/nunit/nunit-vs-adapter/releases/latest">NUnit Test Adapter 2.1.1</a></td>
@@ -181,6 +181,10 @@ permalink: /download/
       <th colspan="2">NUnit 3 Console</th>
     </tr>
     <tr>
+      <td><a href="https://github.com/nunit/nunit-console/releases/tag/3.8">NUnit Console 3.8</a></td>
+      <td class="text-right">January 27, 2017</td>
+    </tr>
+    <tr>
       <td><a href="https://github.com/nunit/nunit-console/releases/tag/3.7">NUnit Console 3.7</a></td>
       <td class="text-right">July 13, 2017</td>
     </tr>
@@ -203,6 +207,10 @@ permalink: /download/
   <table class="table table-condensed table-striped">
     <tr>
       <th colspan="2">NUnit 2</th>
+    </tr>
+    <tr>
+      <td><a href="https://github.com/nunit/nunitv2/releases/tag/2.6.4">NUnit 2.6.4</a></td>
+      <td class="text-right">December 16, 2014</td>
     </tr>
     <tr>
       <td><a href="http://launchpad.net/nunitv2/trunk/2.6.3">NUnit 2.6.3</a></td>


### PR DESCRIPTION
Console 3.9 release is out, updating the website. Also noticed some of our other downloads were out of date.