### PR TITLE
NUnit Console 3.11 release

### DIFF
--- a/_posts/2020-01-26-nunit-console-3.11
+++ b/_posts/2020-01-26-nunit-console-3.11
@@ -1,0 +1,10 @@
+---
+layout: post
+title:  "NUnit Console and Engine 3.11 Released"
+date:   2020-01-26 12:00:00 -0000
+categories: news update nunit
+---
+
+Version 3.11 of the NUnit Console and Engine has now been released. This release fixes a range of minor bugs, and includes a significant amount of internal restructuring work. In future, this will enable improved .NET Standard support in the engine, and a .NET Core build of the console.
+
+You may download NUnit Console 3.10 from [Github](https://github.com/nunit/nunit-console/releases). See the [release notes](https://github.com/nunit/docs/wiki/Console-Release-Notes) for more information.

--- a/_posts/2020-01-26-nunit-console-3.11
+++ b/_posts/2020-01-26-nunit-console-3.11
@@ -5,6 +5,6 @@ date:   2020-01-26 12:00:00 -0000
 categories: news update nunit
 ---
 
-Version 3.11 of the NUnit Console and Engine has now been released. This release fixes a range of minor bugs, and includes a significant amount of internal restructuring work. In future, this will enable improved .NET Standard support in the engine, and a .NET Core build of the console.
+Version 3.11 of the NUnit Console and Engine has now been released. This release fixes a range of minor bugs and includes a significant amount of internal restructuring work. In future, this will enable improved .NET Standard support in the engine and a .NET Core build of the console.
 
 You may download NUnit Console 3.10 from [Github](https://github.com/nunit/nunit-console/releases). See the [release notes](https://github.com/nunit/docs/wiki/Console-Release-Notes) for more information.

--- a/download.html
+++ b/download.html
@@ -9,7 +9,7 @@ permalink: /download/
 
   <div class="col-sm-6">
     <h3>Download Types</h3>
-    <p>The preferred way to download NUnit is through <a href="https://www.nuget.org/">NuGet</a> package manager.</p>
+    <p>The preferred way to download NUnit is through the <a href="https://www.nuget.org/">NuGet</a> package manager.</p>
     <p>The latest releases of can always be found on the relevant GitHub releases pages.</p>
   </div>
 

--- a/download.html
+++ b/download.html
@@ -9,13 +9,8 @@ permalink: /download/
 
   <div class="col-sm-6">
     <h3>Download Types</h3>
-
-    <p>The prefered way to download NUnit is through <a href="https://www.nuget.org/packages/NUnit/">NuGet</a> package manager.</p>
-
-    <p>NUnit Xamarin Runners are also available through <a href="https://www.nuget.org/packages/nunit.xamarin/">NuGet</a> or
-      from <a href="https://github.com/nunit/nunit.xamarin/releases">GitHub</a>.
-
-      <p>The latest releases of NUnit 3 can always be found on the <a href="https://github.com/nunit/nunit/releases">GitHub releases pages</a>.</p>
+    <p>The preferred way to download NUnit is through <a href="https://www.nuget.org/">NuGet</a> package manager.</p>
+    <p>The latest releases of can always be found on the relevant GitHub releases pages.</p>
   </div>
 
   <div class="col-sm-6">
@@ -28,8 +23,8 @@ permalink: /download/
         <td class="text-right">May 14, 2019</td>
       </tr>
       <tr>
-        <td><a href="https://github.com/nunit/nunit-console/releases/latest">NUnit Console 3.10</a></td>
-        <td class="text-right">March 24, 2019</td>
+        <td><a href="https://github.com/nunit/nunit-console/releases/latest">NUnit Console 3.11</a></td>
+        <td class="text-right">January 26, 2020</td>
       </tr>
       <tr>
         <td><a href="https://github.com/nunit/nunit3-vs-adapter/releases/latest">NUnit Test Adapter 3.15.1</a></td>
@@ -191,6 +186,10 @@ permalink: /download/
   <table class="table table-condensed table-striped">
     <tr>
       <th colspan="2">NUnit 3 Console</th>
+    </tr>
+    <tr>
+      <td><a href="https://github.com/nunit/nunit-console/releases/tag/v3.10">NUnit Console 3.10</a></td>
+      <td class="text-right">March 24, 2019</td>
     </tr>
     <tr>
       <td><a href="https://github.com/nunit/nunit-console/releases/tag/v3.9">NUnit Console 3.9</a></td>


### PR DESCRIPTION
Add the 3.11 release of the console.

I also made a couple of changes to the download page, to make it more general, and less framework oriented.