### PR TITLE
Switch from Gitter to Slack

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -7,7 +7,7 @@
   <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
 
   <link rel="stylesheet" href="/css/main.css"">
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
+  <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.3/css/all.css">
   <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ site.rss_path }}"">
   <link rel="alternate" type="application/atom+xml" title="{{ site.title }}" href="{{ site.atom_path }}" />
   <link rel="shortcut icon" href="/favicon.ico" />

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -15,13 +15,13 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="https://docs.nunit.org" target="_blank"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
-            <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
-            <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
-            <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>
+            <li><a href="/news/"><i class="fas fa-comment-dots"></i> News</a></li>
+            <li><a href="/download/"><i class="fas fa-download"></i> Download</a></li>
+            <li><a href="https://docs.nunit.org" target="_blank"><i class="fas fa-book"></i> Documentation</a></li>
+            <li><a href="/contact/"><i class="fas fa-envelope"></i> Contact</a></li>
+            <li><a href="https://twitter.com/nunit" target="_blank"><i class="fab fa-twitter"></i> Twitter</a></li>
+            <li><a href="https://join.slack.com/t/nunit/shared_invite/zt-jz58jw68-Led8y3WH4n2a~Y5WjuOpKA" target="_blank"><i class="fab fa-slack"></i> Slack</a></li>
+            <li><a href="https://github.com/nunit" target="_blank"><i class="fab fa-github"></i> GitHub</a></li>
         </ul>
     </div><!--/.nav-collapse -->
     </div>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -7,7 +7,7 @@ layout: default
         <article>
 
             <header>
-                <h1>{% if page.icon %}<i class="fa {{ page.icon }}"></i> {% endif %}{{ page.title }}</h1>
+                <h1>{% if page.icon %}<i class="fas {{ page.icon }}"></i> {% endif %}{{ page.title }}</h1>
             </header>
 
             <div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -8,7 +8,7 @@ layout: default
             <header>
                 <h1 itemprop="name headline">{{ page.title }}</h1>
                 <p>
-                    <em><i class="fa fa-calendar" aria-hidden="true"></i> <time datetime="{{ page.date | date_to_xmlschema }}" itemprop="datePublished">{{ page.date | date: "%b %-d, %Y" }}</time></em>
+                    <em><i class="fas fa-calendar" aria-hidden="true"></i> <time datetime="{{ page.date | date_to_xmlschema }}" itemprop="datePublished">{{ page.date | date: "%b %-d, %Y" }}</time></em>
                     {% if page.author %}
                      • <span itemprop="author" itemscope itemtype="http://schema.org/Person"><span itemprop="name">{{ page.author }}</span></span>
                     {% endif %}</p>

--- a/contact.md
+++ b/contact.md
@@ -1,16 +1,16 @@
 ---
 layout: page
 title: Contact Us
-icon: fa-envelope-o
+icon: fa-envelope
 permalink: /contact/
 ---
 
-The [nunit-discuss](http://groups.google.com/group/nunit-discuss) mailing list is the best place to start. It is monitored regularly
+The [NUnit Slack Channel](https://join.slack.com/t/nunit/shared_invite/zt-jz58jw68-Led8y3WH4n2a~Y5WjuOpKA) is the best place to start. It is monitored regularly
 by the NUnit developers and other experienced users. Describe your problem clearly and be sure to indicate the version of NUnit you are using.
 
-**Note:** The list moderates all posts from non-subscribers. To prevent moderation, subscribe to the list first, using the same email address from which you plan to post.
+If you are interested in submitting code to NUnit, you can also read through our [contribution guidelines](https://github.com/nunit/nunit/blob/master/CONTRIBUTING.md) for more information on getting involved.
 
-## <i class="fa fa-bug"></i> Report a bug or Request a new feature
+## <i class="fas fa-bug"></i> Report a bug or Request a new feature
 
 Before you report a bug against NUnit, run your tests in the console first. This will help us determine if the bug is with the framework or the test runner you are using.
 
@@ -23,16 +23,6 @@ If you are not sure where to report a particular problem, please ask! If you are
 - [NUnit Framework](http://github.com/nunit/nunit/issues)
 - [NUnit Console Runner and Engine](http://github.com/nunit/nunit-console/issues)
 - [NUnit 3 VS Adapter](http://github.com/nunit/nunit3-vs-adapter/issues)
-- [NUnit Xamarin Runner](http://github.com/nunit/nunit.xamarin/issues)
-- [NUnit Templates](http://github.com/nunit/nunit-vs-templates/issues)
-- [NUnit VS Adapter](http://github.com/nunit/nunit-vs-adapter/issues)
 - [NUnit 3 Test Project Template for dotnet new CLI](http://github.com/nunit/dotnet-new-nunit/issues)
 
 **Note:** Bugs are no longer accepted on the NUnit V2 and NUnitLite projects. NUnit V2 bugs should be filed against the most appropriate project above and we'll check to see the problem doesn't occur in NUnit 3. NUnitLite bugs should be filed against the NUnit Framework, noting that the bug was found in the nunitlite environment.
-
-## <i class="fa fa-comment-o"></i> To discuss or contribute to NUnit development
-
-Start by joining the [nunit-developer list](http://groups.google.com/group/nunit-developer) and introducing yourself. This list is for development discussions about NUnit.
-It's open to everyone and is the best place to discuss your ideas or to learn how to contribute to NUnit.
-
-You can then read through our [contribution guidelines](https://github.com/nunit/nunit/blob/master/CONTRIBUTING.md) for more information on getting involved.

--- a/donations.md
+++ b/donations.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Donations
-icon: fa-usd
+icon: fa-usd-circle
 permalink: /donations/
 ---
 

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@ layout: default
     <div class="content">
         <div class="row">
             <div class="col-sm-12">
-                <h2><i class="fa fa-info-circle"></i> What Is NUnit?</h2>
+                <h2><i class="fas fa-info-circle fa-sm"></i> What Is NUnit?</h2>
 
                 <p>NUnit is a unit-testing framework for all .Net languages. Initially ported from <a href="http://www.junit.org/">JUnit</a>, the current
                     production release, version 3, has been completely rewritten with many new features and support for a wide range of
@@ -31,7 +31,7 @@ layout: default
             </div>
         </div>
 
-        <h2><i class="fa fa-bullhorn"></i> NUnit is a part of the .NET Foundation</h2>
+        <h2><i class="fas fa-bullhorn fa-sm"></i> NUnit is a part of the .NET Foundation</h2>
         <div class="row">
             <div class="col-sm-2 center-block">
               <img src="/img/dotnetfoundation.png" width="130" alt=".NET Foundation" />
@@ -60,7 +60,7 @@ layout: default
         <div class="row">
 
             <div class="col-sm-6">
-                <h2><i class="fa fa-check-square-o"></i> License</h2>
+                <h2><i class="far fa-check-square fa-sm"></i> License</h2>
 
                 <p>NUnit is Open Source software and NUnit 3 is released under the <a href="/nuget/nunit3-license.txt">MIT license</a>. Earlier releases
                     used the <a href="/nuget/license.html">NUnit license</a>.</p>
@@ -70,7 +70,7 @@ layout: default
             </div>
 
             <div class="col-sm-6">
-                <h2><i class="fa fa-user"></i> About Us</h2>
+                <h2><i class="fas fa-user fa-sm"></i> About Us</h2>
 
                 <p>NUnit 3 was created by <a href="http://www.charliepoole.org/">Charlie Poole</a>, <a href="http://www.alteridem.net/">Rob Prouse</a>,
                 <a href="http://simoneb.github.io/">Simone Busoli</a>, Neil Colvin and numerous community contributors.</p>

--- a/news.html
+++ b/news.html
@@ -7,7 +7,7 @@ permalink: /news/
 <div class="container">
   <div class="content">
 
-    <h1><i class="fa fa-commenting-o"></i> News</h1>
+    <h1><i class="fas fa-comment-dots"></i> News</h1>
 
     <div class="row">
       <div class="col-sm-8">


### PR DESCRIPTION
This switches from Gitter to Slack. At the same time, I updated FontAwesome from 4.x to 5.x. I also removed the references to the mailing lists.