### PR TITLE
fix content goes off-screen on a tablet

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,15 +4,12 @@ layout: default
 <div class="jumbotron hidden-xs">
   <div class="container">
     <div class="row">
-      <div class="col-sm-4">
+      <div class="col-sm-6">
         <object data="/img/nunit_logo.svg" type="image/svg+xml" height="128">
           <img src="/img/nunit_logo_128.png" />
         </object>
       </div>
-      <div class="col-sm-6">
-
-      </div>
-      <div class="col-sm-2">
+      <div class="col-sm-6 text-right">
         <a class="btn btn-danger btn-lg" href="/download/" role="button">Download <i class="fa fa-download"></i></a>
       </div>
     </div>


### PR DESCRIPTION
https://github.com/nunit/nunit.github.io/issues/100
after fix
![10-12-2021 19-12-28](https://user-images.githubusercontent.com/26163841/145614680-5b5a5b39-eb69-40c0-80fe-6d6e9bfc2791.jpg)

on the desktop the button(download) is more to the right than it is now, write if it is critical