### PR TITLE
Update latest version of NUnit Console and Engine to 3.20

### DIFF
--- a/download.html
+++ b/download.html
@@ -31,8 +31,8 @@ permalink: /download/
         <td class="text-right">Feb 1, 2024</td>
       </tr>
       <tr>
-        <td><a href="https://github.com/nunit/nunit-console/releases/latest">NUnit Console 3.17.0</a></td>
-        <td class="text-right">January 24, 2024</td>
+        <td><a href="https://github.com/nunit/nunit-console/releases/latest">NUnit Console 3.20.0</a></td>
+        <td class="text-right">April 4, 2025</td>
       </tr>
       <tr>
         <td><a href="https://github.com/nunit/nunit-vs-testgenerator/releases/latest">NUnit Test Generator 3.0</a></td>


### PR DESCRIPTION
The download page is static html, so I updated the date and last version for nunit-console.

Other downloads are also out of date. Maybe this page could be generated in some way to avoid the need to update it.