### PR TITLE
Use RenovateBot to keep versions up to date

### DIFF
--- a/download.html
+++ b/download.html
@@ -16,31 +16,30 @@ permalink: /download/
   <div class="col-sm-6">
     <table class="table table-condensed table-striped">
       <tr>
-        <th colspan="2">Latest NUnit Releases</th>
+        <th>Latest NUnit Releases</th>
       </tr>
       <tr>
+        <!-- renovate: datasource=github-releases depName=nunit/nunit -->
         <td><a href="https://github.com/nunit/nunit/releases/latest">NUnit 4.4.0</a></td>
-        <td class="text-right">Aug 10, 2025</td>
       </tr>
       <tr>
+        <!-- renovate: datasource=github-releases depName=nunit/nunit3-vs-adapter -->
         <td><a href="https://github.com/nunit/nunit3-vs-adapter/releases/latest">NUnit Test Adapter 6.0.0</a></td>
-        <td class="text-right">Dec 6, 2025</td>
       </tr>
       <tr>
+        <!-- renovate: datasource=github-releases depName=nunit/nunit.analyzers -->
         <td><a href="https://github.com/nunit/nunit.analyzers/releases">NUnit Analyzers 4.11.2</a></td>
-        <td class="text-right">Nov 2, 2025</td>
       </tr>
       <tr>
+        <!-- renovate: datasource=github-releases depName=nunit/nunit-console -->
         <td><a href="https://github.com/nunit/nunit-console/releases/latest">NUnit Console 3.21.0</a></td>
-        <td class="text-right">Dec 6, 2025</td>
       </tr>
       <tr>
+        <!-- renovate: datasource=github-releases depName=nunit/nunit-vs-testgenerator -->
         <td><a href="https://github.com/nunit/nunit-vs-testgenerator/releases/latest">NUnit Test Generator 3.0</a></td>
-        <td class="text-right">March 7, 2023</td>
       </tr>
       <tr>
         <td><a href="https://github.com/nunit/dotnet-new-nunit/releases/latest">NUnit 3 Template for dotnet new CLI 1.9.0 (archived)</a></td>
-        <td class="text-right">March 31, 2022</td>
       </tr>
     </table>
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^download\\.html$"],
+      "matchStrings": [
+        "<!--\\s*renovate:\\s*datasource=(?<datasource>[a-z-]+)\\s+depName=(?<depName>\\S+)\\s*-->\\s*\\r?\\n\\s*<td><a [^>]+>[^<]*?(?<currentValue>\\d+(?:\\.\\d+)+(?:-[A-Za-z0-9.-]+)?)</a></td>"
+      ],
+      "extractVersionTemplate": "^v?(?<version>.+)$",
+      "versioningTemplate": "semver-coerced"
+    }
+  ]
+}


### PR DESCRIPTION
Resolves #164

## Summary

The "Latest NUnit Releases" table on `download.html` was being maintained manually, which led to stale version numbers and dates. This PR hands version maintenance to Renovate so the page stays current automatically.

## Changes

- **`download.html`** — added `<!-- renovate: ... -->` markers above the 5 actively-maintained NUnit repos, and dropped the "release date" column from the active-releases table (Renovate updates the version string but cannot write a sibling release date, and the date is one click away on the GitHub release page).
- **`renovate.json`** (new) — declares a regex `customManager` pointed at `download.html`, using the `github-releases` datasource and `semver-coerced` versioning so both `4.4.0` and `3.0`-style tags resolve correctly. `extractVersionTemplate: "^v?(?<version>.+)$"` strips a leading `v` so repos that tag `v4.5.0` produce a clean `4.5.0` in the page.

## Scope

Renovate-managed (5 repos):
- `nunit/nunit`
- `nunit/nunit3-vs-adapter`
- `nunit/nunit.analyzers`
- `nunit/nunit-console`
- `nunit/nunit-vs-testgenerator`

Intentionally **not** managed (no expected new releases):
- `nunit/dotnet-new-nunit` (archived)
- `nunit-legacy/nunitv2` (legacy NUnit 2)
- `nunit/nunit-vs-adapter` (legacy NUnit 2 adapter)

The "Older Releases" tables are historical and remain static.

## How it works

The regex spans the marker comment and the next-line `<td>` in a single multi-line match. Renovate replaces the literal substring captured by `currentValue` (e.g. `4.4.0`) with the new version it resolves from the datasource. The HTML comment is just a marker the regex deliberately reads — there's no Renovate-built-in comment syntax involved.

## Validation

Ran `npx renovate --platform=local` locally with `LOG_LEVEL=debug` and a GitHub token. Output confirms:

- Extraction picks up all 5 deps: `"regex": {"fileCount": 1, "depCount": 5}`
- Each marker resolves to the correct GitHub repo
- 4 of 5 deps are detected as having newer releases:

| Dep | Current | Detected new |
|---|---|---|
| `nunit/nunit` | 4.4.0 | 4.5.1 |
| `nunit/nunit3-vs-adapter` | 6.0.0 | 6.2.0 |
| `nunit/nunit.analyzers` | 4.11.2 | 4.12.0 |
| `nunit/nunit-console` | 3.21.0 | 3.22.0 |
| `nunit/nunit-vs-testgenerator` | 3.0 | (already latest) |

## What to expect after merge

On its next scheduled run, the org's Renovate should open 4 PRs against this repo — one per outdated dep above — each touching a single line in `download.html`. The dependency dashboard issue will list all 5 managed deps.

## Follow-ups (optional)

- If the NUnit org has a base Renovate preset (e.g. `local>nunit/.github`), swap `"extends": ["config:recommended"]` to that preset so this repo inherits org defaults.
- To add a new repo to auto-management later, add a `<!-- renovate: datasource=github-releases depName=<owner>/<repo> -->` line above its `<td>` row — no `renovate.json` change needed.
